### PR TITLE
Add caching. Support limiting the depth of the graph.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,9 @@ recursively search for required files.
     browserify-graph <file>
 
 Outputs a graph of all required files, starting at `<file>`.
+
+Optionally, you can specify:
+    --depth/-d <depth> #only go depth levels deep in the graph
+    --noExternal don't walk external dependencies (anything with node_modules in the path)
+
+    browserify-graph --depth <depth> --noExternal <file>

--- a/browserify-graph
+++ b/browserify-graph
@@ -2,38 +2,66 @@
 
 var detective = require('detective'),
     resolve = require('browser-resolve'),
-    fs = require('fs'),
+    fs = require('graceful-fs'),
     path = require('path'),
     async = require('async'),
-    archy = require('archy');
+    archy = require('archy'),
+    optimist = require('optimist');
 
-if (process.argv.length < 3) {
-    console.error('Usage: browserify-graph <file>');
-    console.error('Prints out a graph of all modules a file depends on');
-    console.error('Uses the same dependency resolution as browserify');
-    process.exit(1);
-}
+var usageString = 'Usage: browserify-graph -d [depth] <file>'
+                + '\nPrints out a graph of all modules a file depends on'
+                + '\nUses the same dependency resolution as browserify';
+
+var argv = optimist
+    .usage(usageString)
+    .alias('depth', 'd')
+    .boolean(['noExternal'])
+    .describe('noExternal', 'Don\'t walk external dependencies')
+    .demand(1)
+    .argv;
 
 var IS_CORE = /^[^\\\/]+$/,
-    file = path.resolve(process.argv[2]),
-    basedir = path.dirname(file);
+    file = path.resolve(argv._[0]),
+    basedir = path.dirname(file),
+    maxDepth = argv.depth || -1,
+    cache = {};
 
-get(file, done);
+get(file, done, 0);
 
-function get(file, callback) {
+function get(file, callback, level) {
     if (IS_CORE.test(file)) {
         return callback(null, { label: file + ' - builtin', nodes: [] });
     }
 
     file = path.resolve(file);
-    fs.readFile(file, 'utf8', read);
+
+    if(argv['noExternal'] && file.indexOf('node_modules') >= 0) {
+        return callback(null, { label: file + ' - external', nodes: [] });
+    }
+
+    if(maxDepth > 0 && level >= maxDepth) {
+        return callback(null, { label: path.relative(basedir, file), nodes: [] });
+    }
+    
+    if(typeof cache[file] === 'undefined' || !cache[file]) {
+        cache[file] = {};
+        fs.readFile(file, 'utf8', read);
+    } else {
+        read(null, null);
+    }
 
     function read(err, contents) {
         if (err) {
             return callback(err);
         }
-
-        var requires = detective(contents);
+        
+        var requires = [];
+        if(typeof cache[file] === 'undefined' || !cache[file] || !cache[file].requires) {
+            requires = detective(contents);
+            cache[file].requires = requires;
+        } else {
+            requires = cache[file].requires;
+        }
         async.map(requires, getDep, gotDeps);
     }
 
@@ -45,7 +73,7 @@ function get(file, callback) {
                 return callback(err);
             }
 
-            return get(p, callback);
+            return get(p, callback, level + 1);
         }
     }
 

--- a/package.json
+++ b/package.json
@@ -1,12 +1,14 @@
 {
   "name": "browserify-graph",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "description": "Print a graph of all modules a file depends on",
   "dependencies": {
     "archy": "~0.0.2",
     "async": "~0.2.9",
     "browser-resolve": "~1.2.0",
-    "detective": "~2.2.0"
+    "detective": "~2.2.0",
+    "graceful-fs": "^3.0.7",
+    "optimist": "^0.6.1"
   },
   "devDependencies": {},
   "bin": {


### PR DESCRIPTION
I wanted to be able to not trace external dependencies and also to limit the depth of the graph returned to make it work with more complex projects (I got an error about too many open files).
